### PR TITLE
Fix issue #5: Use parameters for query limit in get_url_records instead of hardcoding LIMIT in SQL

### DIFF
--- a/block_freq_accessed_links.php
+++ b/block_freq_accessed_links.php
@@ -83,10 +83,10 @@ class block_freq_accessed_links extends block_base {
         FROM {block_freq_accessed_links}
         WHERE user_id=:id
         GROUP BY url
-        ORDER BY occurrences DESC
-        LIMIT $limit";
-
-        $records = $DB->get_records_sql($query, ['id' => $USER->id]);
+        ORDER BY occurrences DESC";
+        
+        $params = ['id' => $USER->id];
+        $records = $DB->get_records_sql($query, $params, 0, $limit);
 
         return $records;
     }


### PR DESCRIPTION

This pull request addresses the issue described in #5. The `get_url_records` function previously took the number of rows to display (`$limit`) directly from an admin configuration setting and embedded it directly into the SQL query string's `LIMIT` clause.
The code has been refactored to use the dedicated $limitnum parameter provided by Moodle's Data Manipulation API via the $DB->get_records_sql function.