### PR TITLE
Add index to user_id in block_freq_accessed_links table

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -14,6 +14,9 @@
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
             </KEYS>
+            <INDEXES>
+                <INDEX NAME="blockfreql_use_ix" UNIQUE="false" FIELDS="user_id"/>
+            </INDEXES>
         </TABLE>
     </TABLES>
 </XMLDB>


### PR DESCRIPTION
This pull request addresses the potential performance issue identified in #6 regarding the SQL query in the `get_url_records` function. When the `block_freq_accessed_links` table becomes large, the query filtering by `user_id` and grouping by `url` can become resource-intensive.

To optimize this, a database index has been added to the `user_id` column within the `block_freq_accessed_links` table definition (`db/install.xml`).

## Changes Made

* Added an `<INDEX>` definition for the `user_id` field in `blocks/freq_accessed_links/db/install.xml`.